### PR TITLE
Screenshots info is not updated when device is plugged in MTP mode

### DIFF
--- a/media/mtp/MtpServer.cpp
+++ b/media/mtp/MtpServer.cpp
@@ -95,6 +95,7 @@ static const MtpEventCode kSupportedEventCodes[] = {
     MTP_EVENT_STORE_ADDED,
     MTP_EVENT_STORE_REMOVED,
     MTP_EVENT_DEVICE_PROP_CHANGED,
+    MTP_EVENT_OBJECT_PROP_CHANGED,
 };
 
 MtpServer::MtpServer(int fd, MtpDatabase* database, bool ptp,
@@ -251,6 +252,11 @@ void MtpServer::sendObjectAdded(MtpObjectHandle handle) {
 void MtpServer::sendObjectRemoved(MtpObjectHandle handle) {
     ALOGV("sendObjectRemoved %d\n", handle);
     sendEvent(MTP_EVENT_OBJECT_REMOVED, handle);
+}
+
+void MtpServer::sendObjectUpdated(MtpObjectHandle handle) {
+    ALOGV("sendObjectUpdated %d\n", handle);
+    sendEvent(MTP_EVENT_OBJECT_PROP_CHANGED, handle);
 }
 
 void MtpServer::sendStoreAdded(MtpStorageID id) {

--- a/media/mtp/MtpServer.h
+++ b/media/mtp/MtpServer.h
@@ -105,6 +105,7 @@ public:
     void                sendObjectAdded(MtpObjectHandle handle);
     void                sendObjectRemoved(MtpObjectHandle handle);
     void                sendDevicePropertyChanged(MtpDeviceProperty property);
+    void                sendObjectUpdated(MtpObjectHandle handle);
 
 private:
     void                sendStoreAdded(MtpStorageID id);


### PR DESCRIPTION
When device is connected as MTP mode and user opens folder
/sdcard/Pictures/Screenshots/ in windows system and captures new
screenshot, image information is always shown as 0 KB

Issue: https://code.google.com/p/android/issues/detail?id=56204

Change-Id: I86d8e1ee54c0d8b2008b5f6bc0de2cac3faafc20